### PR TITLE
npm ims-lti

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     }
   ],
   "dependencies": {
-    "ims-lti": "https://github.com/dmapper/ims-lti",
+    "ims-lti": "^3.0.2",
     "passport-strategy": "1.0.x"
   },
   "main": "./lib"


### PR DESCRIPTION
Replaces a repository link with npm version of the module